### PR TITLE
Updating and moving the grammar to a separate file

### DIFF
--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,18 +1,23 @@
 expression              = terminating-expression /
                            root-expression /
                            wildcard-values
-root-expression         = subexpression / index-expression / flatten /
+root-expression         = non-test / not / binary-expression
+non-test                = subexpression / index-expression / flatten /
                            wildcard-index / filter-expression /
                            identifier / current-node / literal /
                            root-multi-select-list / multi-select-hash /
                            function-expression / group / slice-expression
-terminating-expression  = pipe-expression / or-expression
-terminating-rhs         = root-expression / wildcard-values / or-expression
+terminating-expression  = pipe-expression / or-expression / and-expression
+terminating-rhs         = root-expression /
+                           wildcard-values /
+                           or-expression /
+                           and-expression
 pipe-expression         = expression "|" terminating-rhs
 or-expression           = (root-expression / wildcard-values) "||" terminating-rhs
+and-expression          = (root-expression / wildcard-values) "&&" terminating-rhs
 wildcard-values         = "*"
 group                   = "(" expression ")"
-subexpression           = (root-expression / wildcard-values)
+subexpression           = (non-test / wildcard-values)
                            (object-predicate / array-predicate)
 object-predicate        = "." ( identifier /
                                 multi-select-list /
@@ -28,9 +33,13 @@ index-expression        = "[" number "]"
 slice-expression        = "[" [number] ":" [number] [ ":" [number] ] "]"
 wildcard-index          = "[*]"
 flatten                 = "[]"
-filter-expression       = "[?" comparison "]"
-comparison              = expression comparator expression
-comparator              = "<" / "<=" / "==" / ">=" / ">" / "!="
+filter-expression       = "[?" (not /
+                                non-test /
+                                terminating-expression /
+                                binary-expression) "]"
+not                     = "!" (non-test / not)
+binary-expression       = expression operator (non-test / wildcard-values)
+operator                = "<" / "<=" / "==" / ">=" / ">" / "!="
 root-multi-select-list  = "[" (root-expression /
                                multiple-values /
                                terminating-expression) "]"
@@ -38,16 +47,15 @@ multi-select-list       = "[" (expression / multiple-values) "]"
 multiple-values         = expression 1*( "," expression )
 multi-select-hash       = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
 keyval-expr             = identifier ":" expression
-function-expression     = unquoted-string (no-args / one-or-more-args)
-no-args                 = "(" ")"
-one-or-more-args        = "(" ( function-arg *( "," function-arg ) ) ")"
+function-expression     = unquoted-string function-args
+function-args           = "(" [function-arg *("," function-arg)] ")"
 function-arg            = expression / expression-type
 current-node            = "@"
 expression-type         = "&" expression
 literal                 = "`" 1*(unescaped-literal / escaped-literal) "`"
-unescaped-literal       = %x20-10FFFF
-                          ; basically any character after and including space
-escaped-literal         = escaped-char / (escape %x60)
+unescaped-literal       = %x20-59 / %x61-10FFFF
+                          ; Any character after and including space, but not `
+escaped-literal         = escaped-char / (escape "`")
 number                  = ["-"] 1*DIGIT
 identifier              = unquoted-string / quoted-string
 unquoted-string         = (ALPHA / "_") *(DIGIT / ALPHA / "_")

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -22,7 +22,7 @@ object-subexpr    = (subexpr / index / flatten / wildcard-index /
                           wildcard-values)
 array-subexpr     = (subexpr / index / flatten / wildcard-index / filter /
                      identifier / current-node / literal / root-multi-list /
-                     function / group / slice / wildcard-values)
+                     function / group / slice / wildcard-values / literal)
                      (index / slice / wildcard-index / flatten / filter)
 
 index             = "[" number "]"
@@ -51,7 +51,7 @@ current-node      = "@"
 
 number            = *"-" 1*DIGIT
 literal           = "`" 1*(unescaped-literal / escaped-literal) "`"
-unescaped-literal = %x20-59 / %x61-10FFFF
+unescaped-literal = %x20-5f / %x61-10FFFF
                      ; Any character after and including space, but not `
 escaped-literal   = escaped-char / (escape "`")
 identifier        = unquoted-string / quoted-string

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,24 +1,24 @@
-expr      = ws (terminal / non-terminal) ws
+expr      = ws ( terminal / non-terminal ) ws
 root-expr = non-test / not / comparison
 non-test  = subexpr / index / flatten / wildcard-index / filter /
             identifier / current-node / literal / root-multi-list /
             multi-hash / function / group / slice
-group     = open-group expr close-group
+group     = begin-group expr end-group
 
 ; Insignificant whitespace is allowed around expr nodes and around the
 ; following structural tokens.
-open-group      = ws "(" ws
-close-group     = ws ")" ws
-open-bracket    = ws "[" ws
-close-bracket   = ws "]" ws
-open-brace      = ws "{" ws
-close-brace     = ws "}" ws
-dot-separator   = ws "." ws
+begin-array     = ws %x5B ws    ; [ left square bracket
+begin-object    = ws %x7B ws    ; { left curly bracket
+end-array       = ws %x5D ws    ; ] right square bracket
+end-object      = ws %x7D ws    ; } right curly bracket
+begin-group     = ws %x28 ws    ; ( left parenthesis
+end-group       = ws %x29 ws    ; ) right parenthesis
+name-separator  = ws %x3A ws    ; : colon
+value-separator = ws %x2C ws    ; , comma
+decimal-point   = ws %x2E ws    ; .
 pipe-separator  = ws "|" ws
 or-separator    = ws "||" ws
 and-separator   = ws "&&" ws
-name-separator  = ws ":" ws
-value-separator = ws "," ws
 lt              = ws "<" ws
 lte             = ws "<=" ws
 gt              = ws ">" ws
@@ -27,18 +27,27 @@ eq              = ws "==" ws
 ne              = ws "!=" ws
 expref-token    = "&" ws
 not-token       = "!" ws
+begin-filter    = "[?" ws
+flatten         = ws "[]" ws
+
+; Insignificant whitespace
+<ws> = <*(
+          %x20 / ; Space
+          %x09 / ; Horizontal tab
+          %x0A / ; Line feed or New line
+          %x0D)> ; Carriage return
 
 ; "&&" binds more tightly than "||"
 ; "||" binds more tightly than "|".
 terminal     = pipe / or / and
 non-terminal = root-expr / wildcard-values
-pipe         = expr pipe-separator (non-terminal / or / and)
-or           = (non-terminal / and) or-separator (non-terminal / or / and)
-and          = non-terminal and-separator (non-terminal / and)
+pipe         = expr pipe-separator ( non-terminal / or / and )
+or           = ( non-terminal / and ) or-separator ( non-terminal / or / and )
+and          = non-terminal and-separator ( non-terminal / and )
 
 ; subexpr handles most that descend into nodes.
 subexpr            = object-subexpr / array-subexpr
-object-subexpr     = object-subexpr-lhs dot-separator object-subexpr-rhs
+object-subexpr     = object-subexpr-lhs decimal-point object-subexpr-rhs
 object-subexpr-lhs = subexpr / index / flatten / wildcard-index /
                      filter / identifier / current-node / literal /
                      multi-hash / function / group / slice / wildcard-values
@@ -51,46 +60,51 @@ array-subexpr-lhs  = subexpr / index / flatten / wildcard-index / filter /
 array-subexpr-rhs  = index / slice / wildcard-index / flatten / filter
 
 ; Array related rules
-index           = open-bracket number close-bracket
-slice           = open-bracket *number name-separator
-                               *number *(name-separator *number)
-                               close-bracket
-wildcard-index   = open-bracket "*" close-bracket
-flatten          = open-bracket close-bracket
-filter           = open-bracket "?" filter-condition close-bracket
+index           = begin-array number end-array
+slice           = begin-array [number] name-separator
+                               [number] [name-separator [number] ]
+                               end-array
+wildcard-index   = begin-array "*" end-array
+filter           = begin-filter filter-condition end-array
 filter-condition = not / non-test / terminal / comparison
 
-not             = not-token (non-test / not)
-comparison      = non-terminal comparator (non-test / not / wildcard-values)
+not             = not-token ( non-test / not )
+comparison      = non-terminal comparator ( non-test / not / wildcard-values )
 comparator      = lt / lte / gt / gte / eq / ne
 
-root-multi-list = open-bracket
-                  (root-expr / multiple-values / terminal)
-                  close-bracket
-multi-list      = open-bracket (expr / multiple-values) close-bracket
+root-multi-list = begin-array
+                  ( root-expr / multiple-values / terminal )
+                  end-array
+multi-list      = begin-array ( expr / multiple-values ) end-array
 multiple-values = expr 1*( value-separator expr )
 
-multi-hash      = open-brace (keyval *(value-separator keyval)) close-brace
+multi-hash      = begin-object ( keyval *( value-separator keyval ) ) end-object
 keyval          = identifier name-separator expr
 
 function        = unquoted-string arg-list
-arg-list        = open-group *1(arg *(value-separator arg)) close-group
+arg-list        = begin-group [ arg *( value-separator arg ) ] end-group
 arg             = expr / expref
 
 expref          = expref-token expr
 wildcard-values = "*"
 current-node    = "@"
 
-number            = *"-" 1*DIGIT
-literal           = "`" 1*(unescaped-literal / escaped-literal) "`"
-unescaped-literal = %x20-5f / %x61-10FFFF
-                     ; Any character after and including space, but not `
-escaped-literal   = escaped-char / (escape "`")
+number            = ["-"] int
+literal           = "`" literal-value "`"
+; literal-value is ambiguous; however, json-value has a higher precedence than
+; non-json-value.
+literal-value     = non-json-value / json-value
+literal-char      = unescaped-literal / escaped-literal
+non-json-value    = 1*( literal-char )
+unescaped-literal = %x20-5f / %x61-10FFFF ; Any character except "`"
+escaped-literal   = escaped-char / ( escape "`" )
+
+; Strings, identifiers, and characters.
 identifier        = unquoted-string / quoted-string
-unquoted-string   = (ALPHA / "_") *(DIGIT / ALPHA / "_")
-quoted-string     = DQUOTE 1*(unescaped-char / escaped-char) DQUOTE
+unquoted-string   = ( ALPHA / "_" ) *( DIGIT / ALPHA / "_" )
+quoted-string     = DQUOTE *char DQUOTE
+char              = unescaped-char / escaped-char
 unescaped-char    = %x20-21 / %x23-5B / %x5D-10FFFF
-                     ; Any character other than "\"
 escape            = %x5C             ; "\"
 escaped-char      = escape (
                      %x22 /          ; "    quotation mark  U+0022
@@ -103,5 +117,18 @@ escaped-char      = escape (
                      %x74 /          ; t    tab             U+0009
                      %x75 4HEXDIG )  ; uXXXX                U+XXXX
 
-; Whitespace is Space, HTAB, LF, or CR
-ws = *(%x20 / %x09 / %x0A / %x0D)
+; JSON related grammar (for literal and string values)
+json-value  = false / null / true / object / array
+json-value  =/ json-number / json-string
+json-string = DQUOTE *literal-char DQUOTE
+false       = %x66.61.6c.73.65   ; false
+null        = %x6e.75.6c.6c      ; null
+true        = %x74.72.75.65      ; true
+object      = begin-object [ member *( value-separator member ) ] end-object
+member      = json-string name-separator json-value
+array       = begin-array [ json-value *( value-separator json-value ) ] end-array
+json-number = ["-"] int [frac] [exp]
+digit1-9    = %x31-39 ; 1-9
+int         = "0" / ( digit1-9 *DIGIT )
+exp         = "e" [ "-" / "+" ] 1*DIGIT
+frac        = decimal-point 1*DIGIT

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,17 +1,19 @@
 expression              = terminating-expression /
                            root-expression /
                            wildcard-values
-group                   = "(" expression ")"
 root-expression         = subexpression / index-expression / flatten /
                            wildcard-index / filter-expression /
                            identifier / current-node / literal /
                            root-multi-select-list / multi-select-hash /
                            function-expression / group / slice-expression
 terminating-expression  = pipe-expression / or-expression
-terminating-rhs         = root-expression / wildcard-values
+terminating-rhs         = root-expression / wildcard-values / or-expression
+pipe-expression         = expression "|" terminating-rhs
+or-expression           = (root-expression / wildcard-values) "||" terminating-rhs
 wildcard-values         = "*"
+group                   = "(" expression ")"
 subexpression           = (root-expression / wildcard-values)
-                          (object-predicate / array-predicate)
+                           (object-predicate / array-predicate)
 object-predicate        = "." ( identifier /
                                 multi-select-list /
                                 multi-select-hash /
@@ -22,8 +24,6 @@ array-predicate         = index-expression /
                            wildcard-index /
                            flatten /
                            filter-expression
-or-expression           = expression "||" terminating-rhs
-pipe-expression         = expression "|" terminating-rhs
 index-expression        = "[" number "]"
 slice-expression        = "[" [number] ":" [number] [ ":" [number] ] "]"
 wildcard-index          = "[*]"

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,53 +1,85 @@
-expr              = terminal / non-terminal
-root-expr         = non-test / not / comparison
-non-test          = subexpr / index / flatten / wildcard-index / filter /
-                     identifier / current-node / literal / root-multi-list /
-                     multi-hash / function / group / slice
-group             = "(" expr ")"
+expr      = ws (terminal / non-terminal) ws
+root-expr = non-test / not / comparison
+non-test  = subexpr / index / flatten / wildcard-index / filter /
+            identifier / current-node / literal / root-multi-list /
+            multi-hash / function / group / slice
+group     = open-group expr close-group
 
-; Terminal expressions stop projections. "&&" binds more tightly than "||".
+; Insignificant whitespace is allowed around expr nodes and around the
+; following structural tokens.
+open-group      = ws "(" ws
+close-group     = ws ")" ws
+open-bracket    = ws "[" ws
+close-bracket   = ws "]" ws
+open-brace      = ws "{" ws
+close-brace     = ws "}" ws
+dot-separator   = ws "." ws
+pipe-separator  = ws "|" ws
+or-separator    = ws "||" ws
+and-separator   = ws "&&" ws
+name-separator  = ws ":" ws
+value-separator = ws "," ws
+lt              = ws "<" ws
+lte             = ws "<=" ws
+gt              = ws ">" ws
+gte             = ws ">=" ws
+eq              = ws "==" ws
+ne              = ws "!=" ws
+expref-token    = "&" ws
+not-token       = "!" ws
+
+; "&&" binds more tightly than "||"
 ; "||" binds more tightly than "|".
-terminal          = pipe / or / and
-non-terminal      = root-expr / wildcard-values
-pipe              = expr "|" (non-terminal / or / and)
-or                = (non-terminal / and) "||" (non-terminal / or / and)
-and               = non-terminal "&&" (non-terminal / and)
+terminal     = pipe / or / and
+non-terminal = root-expr / wildcard-values
+pipe         = expr pipe-separator (non-terminal / or / and)
+or           = (non-terminal / and) or-separator (non-terminal / or / and)
+and          = non-terminal and-separator (non-terminal / and)
 
-; subexpr handles most rules, including a.b, a[0], a[::-1], a.*, etc.
-subexpr           = object-subexpr / array-subexpr
-object-subexpr    = (subexpr / index / flatten / wildcard-index /
+; subexpr handles most that descend into nodes.
+subexpr            = object-subexpr / array-subexpr
+object-subexpr     = object-subexpr-lhs dot-separator object-subexpr-rhs
+object-subexpr-lhs = subexpr / index / flatten / wildcard-index /
                      filter / identifier / current-node / literal /
-                     multi-hash / function / group / slice / wildcard-values)
-                     "." (identifier / multi-list / multi-hash / function /
-                          wildcard-values)
-array-subexpr     = (subexpr / index / flatten / wildcard-index / filter /
+                     multi-hash / function / group / slice / wildcard-values
+object-subexpr-rhs = identifier / multi-list / multi-hash / function /
+                     wildcard-values
+array-subexpr      = array-subexpr-lhs array-subexpr-rhs
+array-subexpr-lhs  = subexpr / index / flatten / wildcard-index / filter /
                      identifier / current-node / literal / root-multi-list /
-                     function / group / slice / wildcard-values / literal)
-                     (index / slice / wildcard-index / flatten / filter)
+                     function / group / slice / wildcard-values / literal
+array-subexpr-rhs  = index / slice / wildcard-index / flatten / filter
 
-index             = "[" number "]"
-slice             = "[" *number ":" *number *(":" *number) "]"
-wildcard-index    = "[*]"
-flatten           = "[]"
+; Array related rules
+index           = open-bracket number close-bracket
+slice           = open-bracket *number name-separator
+                               *number *(name-separator *number)
+                               close-bracket
+wildcard-index   = open-bracket "*" close-bracket
+flatten          = open-bracket close-bracket
+filter           = open-bracket "?" filter-condition close-bracket
+filter-condition = not / non-test / terminal / comparison
 
-filter            = "[?" (not / non-test / terminal / comparison) "]"
-not               = "!" (non-test / not)
-comparison        = non-terminal comparator (non-test / not / wildcard-values)
-comparator        = "<" / "<=" / "==" / ">=" / ">" / "!="
+not             = not-token (non-test / not)
+comparison      = non-terminal comparator (non-test / not / wildcard-values)
+comparator      = lt / lte / gt / gte / eq / ne
 
-root-multi-list   = "[" (root-expr / multiple-values / terminal) "]"
-multi-list        = "[" (expr / multiple-values) "]"
-multiple-values   = expr 1*( "," expr )
-multi-hash        = "{" ( keyval *( "," keyval ) ) "}"
-keyval            = identifier ":" expr
+root-multi-list = open-bracket
+                  (root-expr / multiple-values / terminal)
+                  close-bracket
+multi-list      = open-bracket (expr / multiple-values) close-bracket
+multiple-values = expr 1*( value-separator expr )
 
-function          = unquoted-string arg-list
-arg-list          = "(" *1(arg *("," arg)) ")"
-arg               = expr / expref
+multi-hash      = open-brace (keyval *(value-separator keyval)) close-brace
+keyval          = identifier name-separator expr
 
-expref            = "&" expr
-wildcard-values   = "*"
-current-node      = "@"
+function        = unquoted-string arg-list
+arg-list        = open-group *1(arg *(value-separator arg)) close-group
+arg             = expr / expref
+
+expref          = expref-token expr
+wildcard-values = "*"
+current-node    = "@"
 
 number            = *"-" 1*DIGIT
 literal           = "`" 1*(unescaped-literal / escaped-literal) "`"
@@ -70,3 +102,6 @@ escaped-char      = escape (
                      %x72 /          ; r    carriage return U+000D
                      %x74 /          ; t    tab             U+0009
                      %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+; Whitespace is Space, HTAB, LF, or CR
+ws = *(%x20 / %x09 / %x0A / %x0D)

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,0 +1,55 @@
+expression             = root / wildcard
+root                   = subexpression / index-expression / flatten
+root                   =/ wildcard-index / filter-expression / or-expression
+root                   =/ identifier / current-node / literal
+root                   =/ root-multi-select-list / multi-select-hash
+root                   =/ function-expression / pipe-expression
+wildcard               = "*"
+subexpression          = expression (object-predicate / array-predicate)
+object-predicate       = "." ( identifier /
+                               multi-select-list /
+                               multi-select-hash /
+                               function-expression /
+                               wildcard )
+array-predicate        = index-expression / wildcard-index
+array-predicate        =/ flatten / filter-expression
+or-expression          = expression "||" expression
+pipe-expression        = expression "|" expression
+index-expression       = "[" number "]"
+wildcard-index         = "[" wildcard "]"
+flatten                = "[]"
+filter-expression      = "[?" comparison "]"
+comparison             = expression comparator expression
+comparator             = "<" / "<=" / "==" / ">=" / ">" / "!="
+root-multi-select-list = "[" (root / multiple-values) "]"
+multi-select-list      = "[" (expression / multiple-values) "]"
+multiple-values        = expression 1*( "," expression )
+multi-select-hash      = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
+keyval-expr            = identifier ":" expression
+function-expression    = unquoted-string (no-args / one-or-more-args)
+no-args                = "(" ")"
+one-or-more-args       = "(" ( function-arg *( "," function-arg ) ) ")"
+function-arg           = expression / expression-type
+current-node           = "@"
+expression-type        = "&" expression
+literal                = "`" 1*(unescaped-literal / escaped-literal) "`"
+unescaped-literal      = %x20-10FFFF
+                          ; basically any character after and including space
+escaped-literal        = escaped-char / (escape %x60)
+number                 = ["-"] 1*DIGIT
+identifier             = unquoted-string / quoted-string
+unquoted-string        = (ALPHA / "_") *(DIGIT / ALPHA / "_")
+quoted-string          = DQUOTE 1*(unescaped-char / escaped-char) DQUOTE
+unescaped-char         = %x20-21 / %x23-5B / %x5D-10FFFF
+                          ; Any character other than "\"
+escape                 = %x5C ; "\"
+escaped-char           = escape (
+                          %x22 /          ; "    quotation mark  U+0022
+                          %x5C /          ; \    reverse solidus U+005C
+                          %x2F /          ; /    solidus         U+002F
+                          %x62 /          ; b    backspace       U+0008
+                          %x66 /          ; f    form feed       U+000C
+                          %x6E /          ; n    line feed       U+000A
+                          %x72 /          ; r    carriage return U+000D
+                          %x74 /          ; t    tab             U+0009
+                          %x75 4HEXDIG )  ; uXXXX                U+XXXX

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,75 +1,72 @@
-expression              = terminating-expression /
-                           root-expression /
-                           wildcard-values
-root-expression         = non-test / not / binary-expression
-non-test                = subexpression / index-expression / flatten /
-                           wildcard-index / filter-expression /
-                           identifier / current-node / literal /
-                           root-multi-select-list / multi-select-hash /
-                           function-expression / group / slice-expression
-terminating-expression  = pipe-expression / or-expression / and-expression
-terminating-rhs         = root-expression /
-                           wildcard-values /
-                           or-expression /
-                           and-expression
-pipe-expression         = expression "|" terminating-rhs
-or-expression           = (root-expression / wildcard-values) "||" terminating-rhs
-and-expression          = (root-expression / wildcard-values) "&&" terminating-rhs
-wildcard-values         = "*"
-group                   = "(" expression ")"
-subexpression           = (non-test / wildcard-values)
-                           (object-predicate / array-predicate)
-object-predicate        = "." ( identifier /
-                                multi-select-list /
-                                multi-select-hash /
-                                function-expression /
-                                wildcard-values )
-array-predicate         = index-expression /
-                           slice-expression /
-                           wildcard-index /
-                           flatten /
-                           filter-expression
-index-expression        = "[" number "]"
-slice-expression        = "[" [number] ":" [number] [ ":" [number] ] "]"
-wildcard-index          = "[*]"
-flatten                 = "[]"
-filter-expression       = "[?" (not /
-                                non-test /
-                                terminating-expression /
-                                binary-expression) "]"
-not                     = "!" (non-test / not)
-binary-expression       = expression operator (non-test / wildcard-values)
-operator                = "<" / "<=" / "==" / ">=" / ">" / "!="
-root-multi-select-list  = "[" (root-expression /
-                               multiple-values /
-                               terminating-expression) "]"
-multi-select-list       = "[" (expression / multiple-values) "]"
-multiple-values         = expression 1*( "," expression )
-multi-select-hash       = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
-keyval-expr             = identifier ":" expression
-function-expression     = unquoted-string function-args
-function-args           = "(" [function-arg *("," function-arg)] ")"
-function-arg            = expression / expression-type
-current-node            = "@"
-expression-type         = "&" expression
-literal                 = "`" 1*(unescaped-literal / escaped-literal) "`"
-unescaped-literal       = %x20-59 / %x61-10FFFF
-                          ; Any character after and including space, but not `
-escaped-literal         = escaped-char / (escape "`")
-number                  = ["-"] 1*DIGIT
-identifier              = unquoted-string / quoted-string
-unquoted-string         = (ALPHA / "_") *(DIGIT / ALPHA / "_")
-quoted-string           = DQUOTE 1*(unescaped-char / escaped-char) DQUOTE
-unescaped-char          = %x20-21 / %x23-5B / %x5D-10FFFF
-                           ; Any character other than "\"
-escape                  = %x5C ; "\"
-escaped-char            = escape (
-                           %x22 /          ; "    quotation mark  U+0022
-                           %x5C /          ; \    reverse solidus U+005C
-                           %x2F /          ; /    solidus         U+002F
-                           %x62 /          ; b    backspace       U+0008
-                           %x66 /          ; f    form feed       U+000C
-                           %x6E /          ; n    line feed       U+000A
-                           %x72 /          ; r    carriage return U+000D
-                           %x74 /          ; t    tab             U+0009
-                           %x75 4HEXDIG )  ; uXXXX                U+XXXX
+expr              = terminal / non-terminal
+root-expr         = non-test / not / comparison
+non-test          = subexpr / index / flatten / wildcard-index / filter /
+                     identifier / current-node / literal / root-multi-list /
+                     multi-hash / function / group / slice
+group             = "(" expr ")"
+
+; Terminal expressions stop projections. "&&" binds more tightly than "||".
+; "||" binds more tightly than "|".
+terminal          = pipe / or / and
+non-terminal      = root-expr / wildcard-values
+pipe              = expr "|" (non-terminal / or / and)
+or                = (non-terminal / and) "||" (non-terminal / or / and)
+and               = non-terminal "&&" (non-terminal / and)
+
+; subexpr handles most rules, including a.b, a[0], a[::-1], a.*, etc.
+subexpr           = object-subexpr / array-subexpr
+object-subexpr    = (subexpr / index / flatten / wildcard-index /
+                     filter / identifier / current-node / literal /
+                     multi-hash / function / group / slice / wildcard-values)
+                     "." (identifier / multi-list / multi-hash / function /
+                          wildcard-values)
+array-subexpr     = (subexpr / index / flatten / wildcard-index / filter /
+                     identifier / current-node / literal / root-multi-list /
+                     function / group / slice / wildcard-values)
+                     (index / slice / wildcard-index / flatten / filter)
+
+index             = "[" number "]"
+slice             = "[" *number ":" *number *(":" *number) "]"
+wildcard-index    = "[*]"
+flatten           = "[]"
+
+filter            = "[?" (not / non-test / terminal / comparison) "]"
+not               = "!" (non-test / not)
+comparison        = non-terminal comparator (non-test / not / wildcard-values)
+comparator        = "<" / "<=" / "==" / ">=" / ">" / "!="
+
+root-multi-list   = "[" (root-expr / multiple-values / terminal) "]"
+multi-list        = "[" (expr / multiple-values) "]"
+multiple-values   = expr 1*( "," expr )
+multi-hash        = "{" ( keyval *( "," keyval ) ) "}"
+keyval            = identifier ":" expr
+
+function          = unquoted-string arg-list
+arg-list          = "(" *1(arg *("," arg)) ")"
+arg               = expr / expref
+
+expref            = "&" expr
+wildcard-values   = "*"
+current-node      = "@"
+
+number            = *"-" 1*DIGIT
+literal           = "`" 1*(unescaped-literal / escaped-literal) "`"
+unescaped-literal = %x20-59 / %x61-10FFFF
+                     ; Any character after and including space, but not `
+escaped-literal   = escaped-char / (escape "`")
+identifier        = unquoted-string / quoted-string
+unquoted-string   = (ALPHA / "_") *(DIGIT / ALPHA / "_")
+quoted-string     = DQUOTE 1*(unescaped-char / escaped-char) DQUOTE
+unescaped-char    = %x20-21 / %x23-5B / %x5D-10FFFF
+                     ; Any character other than "\"
+escape            = %x5C             ; "\"
+escaped-char      = escape (
+                     %x22 /          ; "    quotation mark  U+0022
+                     %x5C /          ; \    reverse solidus U+005C
+                     %x2F /          ; /    solidus         U+002F
+                     %x62 /          ; b    backspace       U+0008
+                     %x66 /          ; f    form feed       U+000C
+                     %x6E /          ; n    line feed       U+000A
+                     %x72 /          ; r    carriage return U+000D
+                     %x74 /          ; t    tab             U+0009
+                     %x75 4HEXDIG )  ; uXXXX                U+XXXX

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -31,11 +31,10 @@ begin-filter    = "[?" ws
 flatten         = ws "[]" ws
 
 ; Insignificant whitespace
-<ws> = <*(
-          %x20 / ; Space
-          %x09 / ; Horizontal tab
-          %x0A / ; Line feed or New line
-          %x0D)> ; Carriage return
+ws = *(%x20 / ; Space
+       %x09 / ; Horizontal tab
+       %x0A / ; Line feed or New line
+       %x0D) ; Carriage return
 
 ; "&&" binds more tightly than "||"
 ; "||" binds more tightly than "|".

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,8 +1,8 @@
 expr      = ws ( terminal / non-terminal ) ws
 root-expr = non-test / not / comparison
 non-test  = subexpr / index / flatten / wildcard-index / filter /
-            identifier / current-node / literal / root-multi-list /
-            multi-hash / function / group / slice
+            identifier / current-node / raw-string / literal /
+            root-multi-list / multi-hash / function / group / slice
 group     = begin-group expr end-group
 
 ; Insignificant whitespace is allowed around expr nodes and around the
@@ -89,16 +89,12 @@ wildcard-values = "*"
 current-node    = "@"
 
 number            = ["-"] int
-literal           = "`" literal-value "`"
-; literal-value is ambiguous; however, json-value has a higher precedence than
-; non-json-value.
-literal-value     = non-json-value / json-value
-literal-char      = unescaped-literal / escaped-literal
-non-json-value    = 1*( literal-char )
-unescaped-literal = %x20-5f / %x61-10FFFF ; Any character except "`"
-escaped-literal   = escaped-char / ( escape "`" )
 
 ; Strings, identifiers, and characters.
+raw-string        = "'" *raw-string-char "'"
+raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / raw-string-escape
+raw-string-escape = escape ["'"]
+
 identifier        = unquoted-string / quoted-string
 unquoted-string   = ( ALPHA / "_" ) *( DIGIT / ALPHA / "_" )
 quoted-string     = DQUOTE *char DQUOTE
@@ -115,6 +111,12 @@ escaped-char      = escape (
                      %x72 /          ; r    carriage return U+000D
                      %x74 /          ; t    tab             U+0009
                      %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+; Literal rules (e.g., "`[]`")
+literal           = "`" json-value "`"
+literal-char      = unescaped-literal / escaped-literal
+unescaped-literal = %x20-5f / %x61-10FFFF ; Any character except "`"
+escaped-literal   = escaped-char / ( escape "`" )
 
 ; JSON related grammar (for literal and string values)
 json-value  = false / null / true / object / array

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,55 +1,67 @@
-expression             = root-expression / wildcard-values
-root-expression        = subexpression / index-expression / flatten
-root-expression        =/ wildcard-index / filter-expression / or-expression
-root-expression        =/ identifier / current-node / literal
-root-expression        =/ root-multi-select-list / multi-select-hash
-root-expression        =/ function-expression / pipe-expression
-wildcard-values        = "*"
-subexpression          = expression (object-predicate / array-predicate)
-object-predicate       = "." ( identifier /
-                               multi-select-list /
-                               multi-select-hash /
-                               function-expression /
-                               wildcard-values )
-array-predicate        = index-expression / wildcard-index
-array-predicate        =/ flatten / filter-expression
-or-expression          = expression "||" expression
-pipe-expression        = expression "|" expression
-index-expression       = "[" number "]"
-wildcard-index         = "[*]"
-flatten                = "[]"
-filter-expression      = "[?" comparison "]"
-comparison             = expression comparator expression
-comparator             = "<" / "<=" / "==" / ">=" / ">" / "!="
-root-multi-select-list = "[" (root-expression / multiple-values) "]"
-multi-select-list      = "[" (expression / multiple-values) "]"
-multiple-values        = expression 1*( "," expression )
-multi-select-hash      = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
-keyval-expr            = identifier ":" expression
-function-expression    = unquoted-string (no-args / one-or-more-args)
-no-args                = "(" ")"
-one-or-more-args       = "(" ( function-arg *( "," function-arg ) ) ")"
-function-arg           = expression / expression-type
-current-node           = "@"
-expression-type        = "&" expression
-literal                = "`" 1*(unescaped-literal / escaped-literal) "`"
-unescaped-literal      = %x20-10FFFF
+expression              = terminating-expression /
+                           root-expression /
+                           wildcard-values
+group                   = "(" expression ")"
+root-expression         = subexpression / index-expression / flatten /
+                           wildcard-index / filter-expression /
+                           identifier / current-node / literal /
+                           root-multi-select-list / multi-select-hash /
+                           function-expression / group / slice-expression
+terminating-expression  = pipe-expression / or-expression
+terminating-rhs         = root-expression / wildcard-values
+wildcard-values         = "*"
+subexpression           = (root-expression / wildcard-values)
+                          (object-predicate / array-predicate)
+object-predicate        = "." ( identifier /
+                                multi-select-list /
+                                multi-select-hash /
+                                function-expression /
+                                wildcard-values )
+array-predicate         = index-expression /
+                           slice-expression /
+                           wildcard-index /
+                           flatten /
+                           filter-expression
+or-expression           = expression "||" terminating-rhs
+pipe-expression         = expression "|" terminating-rhs
+index-expression        = "[" number "]"
+slice-expression        = "[" [number] ":" [number] [ ":" [number] ] "]"
+wildcard-index          = "[*]"
+flatten                 = "[]"
+filter-expression       = "[?" comparison "]"
+comparison              = expression comparator expression
+comparator              = "<" / "<=" / "==" / ">=" / ">" / "!="
+root-multi-select-list  = "[" (root-expression /
+                               multiple-values /
+                               terminating-expression) "]"
+multi-select-list       = "[" (expression / multiple-values) "]"
+multiple-values         = expression 1*( "," expression )
+multi-select-hash       = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
+keyval-expr             = identifier ":" expression
+function-expression     = unquoted-string (no-args / one-or-more-args)
+no-args                 = "(" ")"
+one-or-more-args        = "(" ( function-arg *( "," function-arg ) ) ")"
+function-arg            = expression / expression-type
+current-node            = "@"
+expression-type         = "&" expression
+literal                 = "`" 1*(unescaped-literal / escaped-literal) "`"
+unescaped-literal       = %x20-10FFFF
                           ; basically any character after and including space
-escaped-literal        = escaped-char / (escape %x60)
-number                 = ["-"] 1*DIGIT
-identifier             = unquoted-string / quoted-string
-unquoted-string        = (ALPHA / "_") *(DIGIT / ALPHA / "_")
-quoted-string          = DQUOTE 1*(unescaped-char / escaped-char) DQUOTE
-unescaped-char         = %x20-21 / %x23-5B / %x5D-10FFFF
-                          ; Any character other than "\"
-escape                 = %x5C ; "\"
-escaped-char           = escape (
-                          %x22 /          ; "    quotation mark  U+0022
-                          %x5C /          ; \    reverse solidus U+005C
-                          %x2F /          ; /    solidus         U+002F
-                          %x62 /          ; b    backspace       U+0008
-                          %x66 /          ; f    form feed       U+000C
-                          %x6E /          ; n    line feed       U+000A
-                          %x72 /          ; r    carriage return U+000D
-                          %x74 /          ; t    tab             U+0009
-                          %x75 4HEXDIG )  ; uXXXX                U+XXXX
+escaped-literal         = escaped-char / (escape %x60)
+number                  = ["-"] 1*DIGIT
+identifier              = unquoted-string / quoted-string
+unquoted-string         = (ALPHA / "_") *(DIGIT / ALPHA / "_")
+quoted-string           = DQUOTE 1*(unescaped-char / escaped-char) DQUOTE
+unescaped-char          = %x20-21 / %x23-5B / %x5D-10FFFF
+                           ; Any character other than "\"
+escape                  = %x5C ; "\"
+escaped-char            = escape (
+                           %x22 /          ; "    quotation mark  U+0022
+                           %x5C /          ; \    reverse solidus U+005C
+                           %x2F /          ; /    solidus         U+002F
+                           %x62 /          ; b    backspace       U+0008
+                           %x66 /          ; f    form feed       U+000C
+                           %x6E /          ; n    line feed       U+000A
+                           %x72 /          ; r    carriage return U+000D
+                           %x74 /          ; t    tab             U+0009
+                           %x75 4HEXDIG )  ; uXXXX                U+XXXX

--- a/docs/jmespath-grammar.txt
+++ b/docs/jmespath-grammar.txt
@@ -1,27 +1,27 @@
-expression             = root / wildcard
-root                   = subexpression / index-expression / flatten
-root                   =/ wildcard-index / filter-expression / or-expression
-root                   =/ identifier / current-node / literal
-root                   =/ root-multi-select-list / multi-select-hash
-root                   =/ function-expression / pipe-expression
-wildcard               = "*"
+expression             = root-expression / wildcard-values
+root-expression        = subexpression / index-expression / flatten
+root-expression        =/ wildcard-index / filter-expression / or-expression
+root-expression        =/ identifier / current-node / literal
+root-expression        =/ root-multi-select-list / multi-select-hash
+root-expression        =/ function-expression / pipe-expression
+wildcard-values        = "*"
 subexpression          = expression (object-predicate / array-predicate)
 object-predicate       = "." ( identifier /
                                multi-select-list /
                                multi-select-hash /
                                function-expression /
-                               wildcard )
+                               wildcard-values )
 array-predicate        = index-expression / wildcard-index
 array-predicate        =/ flatten / filter-expression
 or-expression          = expression "||" expression
 pipe-expression        = expression "|" expression
 index-expression       = "[" number "]"
-wildcard-index         = "[" wildcard "]"
+wildcard-index         = "[*]"
 flatten                = "[]"
 filter-expression      = "[?" comparison "]"
 comparison             = expression comparator expression
 comparator             = "<" / "<=" / "==" / ">=" / ">" / "!="
-root-multi-select-list = "[" (root / multiple-values) "]"
+root-multi-select-list = "[" (root-expression / multiple-values) "]"
 multi-select-list      = "[" (expression / multiple-values) "]"
 multiple-values        = expression 1*( "," expression )
 multi-select-hash      = "{" ( keyval-expr *( "," keyval-expr ) ) "}"

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -26,103 +26,10 @@ language equivalent value.
 Grammar
 =======
 
-The grammar is specified using ABNF, as described in `RFC4234`_
+The :download:`JMESPath grammar <jmespath-grammar.txt>` is specified using ABNF,
+as described in `RFC4234`_
 
-::
-
-    expression        = sub-expression / index-expression / or-expression / identifier
-    expression        =/ "*" / multi-select-list / multi-select-hash / literal
-    expression        =/ function-expression / pipe-expression
-    sub-expression    = expression "." ( identifier /
-                                         multi-select-list /
-                                         multi-select-hash /
-                                         function-expression /
-                                         "*" )
-    or-expression     = expression "||" expression
-    pipe-expression   = expression "|" expression
-    index-expression  = expression bracket-specifier / bracket-specifier
-    multi-select-list = "[" ( expression *( "," expression ) ) "]"
-    multi-select-hash = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
-    keyval-expr       = identifier ":" expression
-    bracket-specifier = "[" (number / "*") "]" / "[]"
-    bracket-specifier =/ "[?" list-filter-expr "]"
-    list-filter-expr  = expression comparator expression
-    comparator        = "<" / "<=" / "==" / ">=" / ">" / "!="
-    function-expression = unquoted-string  (
-                            no-args  /
-                            one-or-more-args )
-    no-args             = "(" ")"
-    one-or-more-args    = "(" ( function-arg *( "," function-arg ) ) ")"
-    function-arg        = expression / current-node / expression-type
-    current-node        = "@"
-    expression-type     = "&" expression
-
-    literal           = "`" json-value "`"
-    literal           =/ "`" 1*(unescaped-literal / escaped-literal) "`"
-    unescaped-literal = %x20-21 /       ; space !
-                            %x23-5A /   ; # - [
-                            %x5D-5F /   ; ] ^ _
-                            %x61-7A     ; a-z
-                            %x7C-10FFFF ; |}~ ...
-    escaped-literal   = escaped-char / (escape %x60)
-    number            = ["-"]1*digit
-    digit             = %x30-39
-    identifier        = unquoted-string / quoted-string
-    unquoted-string   = (%x41-5A / %x61-7A / %x5F) *(  ; a-zA-Z_
-                            %x30-39  /  ; 0-9
-                            %x41-5A /  ; A-Z
-                            %x5F    /  ; _
-                            %x61-7A)   ; a-z
-    quoted-string     = quote 1*(unescaped-char / escaped-char) quote
-    unescaped-char    = %x20-21 / %x23-5B / %x5D-10FFFF
-    escape            = %x5C   ; Back slash: \
-    quote             = %x22   ; Double quote: '"'
-    escaped-char      = escape (
-                            %x22 /          ; "    quotation mark  U+0022
-                            %x5C /          ; \    reverse solidus U+005C
-                            %x2F /          ; /    solidus         U+002F
-                            %x62 /          ; b    backspace       U+0008
-                            %x66 /          ; f    form feed       U+000C
-                            %x6E /          ; n    line feed       U+000A
-                            %x72 /          ; r    carriage return U+000D
-                            %x74 /          ; t    tab             U+0009
-                            %x75 4HEXDIG )  ; uXXXX                U+XXXX
-
-    ; The ``json-value`` is any valid JSON value with the one exception that the
-    ; ``%x60`` character must be escaped.  While it's encouraged that implementations
-    ; use any existing JSON parser for this grammar rule (after handling the escaped
-    ; literal characters), the grammar rule is shown below for completeness::
-
-    json-value = false / null / true / json-object / json-array /
-                 json-number / json-quoted-string
-    false = %x66.61.6c.73.65   ; false
-    null  = %x6e.75.6c.6c      ; null
-    true  = %x74.72.75.65      ; true
-    json-quoted-string = %x22 1*(unescaped-literal / escaped-literal) %x22
-    begin-array     = ws %x5B ws  ; [ left square bracket
-    begin-object    = ws %x7B ws  ; { left curly bracket
-    end-array       = ws %x5D ws  ; ] right square bracket
-    end-object      = ws %x7D ws  ; } right curly bracket
-    name-separator  = ws %x3A ws  ; : colon
-    value-separator = ws %x2C ws  ; , comma
-    ws              = *(%x20 /              ; Space
-                        %x09 /              ; Horizontal tab
-                        %x0A /              ; Line feed or New line
-                        %x0D                ; Carriage return
-                       )
-    json-object = begin-object [ member *( value-separator member ) ] end-object
-    member = quoted-string name-separator json-value
-    json-array = begin-array [ json-value *( value-separator json-value ) ] end-array
-    json-number = [ minus ] int [ frac ] [ exp ]
-    decimal-point = %x2E       ; .
-    digit1-9 = %x31-39         ; 1-9
-    e = %x65 / %x45            ; e E
-    exp = e [ minus / plus ] 1*DIGIT
-    frac = decimal-point 1*DIGIT
-    int = zero / ( digit1-9 *DIGIT )
-    minus = %x2D               ; -
-    plus = %x2B                ; +
-    zero = %x30                ; 0
+.. literalinclude:: jmespath-grammar.txt
 
 .. _identifiers:
 
@@ -481,26 +388,29 @@ Literal Expressions
 
 ::
 
-    literal           = "`" json-value "`"
-    literal           =/ "`" 1*(unescaped-literal / escaped-literal) "`"
-    unescaped-literal = %x20-21 /       ; space !
-                            %x23-5A /   ; # - [
-                            %x5D-5F /   ; ] ^ _
-                            %x61-7A     ; a-z
-                            %x7C-10FFFF ; |}~ ...
+    literal           = "`" 1*(unescaped-literal / escaped-literal) "`"
+    unescaped-literal = %x20-10FFFF
     escaped-literal   = escaped-char / (escape %x60)
 
 A literal expression is an expression that allows arbitrary JSON objects to be
-specified.  This is useful in filter expressions as well as multi select hashes
+specified. This is useful in filter expressions as well as multi select hashes
 (to create arbitrary key value pairs), but is allowed anywhere an expression is
-allowed.  The specification includes the ABNF for JSON, implementations should
-use an existing JSON parser to parse literal values.  Note that the ``\```
-character must now be escaped in a ``json-value`` which means implementations
-need to handle this case before passing the resulting string to a JSON parser.
+allowed.
 
-Note the second literal rule.  This is used to specify a string such that
-double quotes do not have to be included.  This means that the literal
-expression ``\`"foo"\``` is equivalent to ``\`foo\```.
+Implementations should use an existing JSON parser to parse literal values when
+a literal expression value is a valid JSON value based on the
+`JSON ABNF <http://www.ietf.org/rfc/rfc4627.txt>`_.
+
+.. note::
+
+    ``\``` may be escaped in a literal expression, which means that
+    implementations need to handle this case before passing the resulting
+    string to a JSON parser.
+
+When a literal value is not a valid JSON value, implementations must add
+surrounding double quote characters to the value and then pass it to a JSON
+parser. This means that the literal expression ``\`"foo"\``` is equivalent to
+``\`foo\```.
 
 
 Examples


### PR DESCRIPTION
This commit simplifies the JMESPath grammar and moved the grammar to a
separate downloadable file.

This is  WIP PR. I'm finding other places in the grammar that I think could be improved.
