### PR TITLE
Show errors in demo result

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -88,9 +88,14 @@ $(document).ready(function() {
     $('.jmespath-demo').each(function(i, el) {
         function evaluateDemo(el) {
             var expression = $(el).find('.jmespath-expression').val();
-            var inputData = JSON.parse($(el).find('.jmespath-input').val());
-            var result = jmespath.search(inputData, expression);
-            $(el).find('.jmespath-result').text(JSON.stringify(result, null, 2));
+            var result;
+            try {
+                var inputData = JSON.parse($(el).find('.jmespath-input').val());
+                result = JSON.stringify(jmespath.search(inputData, expression), null, 2);
+            } catch(e) {
+                result = 'Error: ' + e.message + ' (' + e.constructor.name + ')';
+            }
+            $(el).find('.jmespath-result').text(result);
         }
         $(el).find('.jmespath-expression').bind('keyup', function() {
             evaluateDemo(el);


### PR DESCRIPTION
I often find myself testing JMESPath expressions using the demo on the site and thinking that my fancy expressions work, when it's actually just the result text that is not being updated. While perhaps not the recommended way to do that, I suppose this change won't hurt.

Previously, any error in the JSON input or JMESPath expression would be silently ignored, and the result not updated. This shows any error during evaluation in the result box.
