### PR TITLE
Update the grammar for escapes in raw strings

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -82,8 +82,10 @@ The grammar is specified using ABNF, as described in `RFC4234`_
     expression-type     = "&" expression
 
     raw-string        = "'" *raw-string-char "'"
-    raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / raw-string-escape
-    raw-string-escape = escape "'"
+    raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / preserved-escape /
+                          raw-string-escape
+    preserved-escape  = escape (%x20-26 / %28-5B / %x5D-10FFFF)
+    raw-string-escape = escape ("'" / escape)
     literal           = "`" json-value "`"
     unescaped-literal = %x20-21 /       ; space !
                             %x23-5B /   ; # - [
@@ -714,8 +716,10 @@ Raw String Literals
 ::
 
   raw-string        = "'" *raw-string-char "'"
-  raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / raw-string-escape
-  raw-string-escape = escape ["'"]
+  raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / preserved-escape /
+                        raw-string-escape
+  preserved-escape  = escape (%x20-26 / %28-5B / %x5D-10FFFF)
+  raw-string-escape = escape ("'" / escape)
 
 A raw string is an expression that allows for a literal string value to be
 specified.  The result of evaluating the raw string literal expression is the
@@ -744,6 +748,7 @@ additional processing that JSON strings supports including:
   search('[baz]', "") -> "[baz]"
   search('[baz]', "") -> "[baz]"
   search('\u03a6', "") -> "\u03a6"
+  search('\\', "") -> "\\"
 
 
 .. _filterexpressions:


### PR DESCRIPTION
There are two different grammars for raw strings in the specification, one that allows lone backslashes and one that does not allow backslash unless followed by single quote.

Not allowing backslashes unless followed by single quote is contradicted by the examples in the specification and by the compliance tests (specifically '\u03a6' is given as a valid raw string in both).

Allowing lone backslashes is problematic since it makes the semantics of '\\' unclear. In the current go implementation, for example, this is treated as an unterminated raw string, but it could equally well be interpreted as a string with two backslashes by another implementation, and neither would be wrong.

This clarifies that we want to treat backslashes literally, except when followed by single quote. Also, to make it possible to end a string with a backslash we also require backslashes to be escaped.