### PR TITLE
Add a reference to jmespath-java

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -33,6 +33,9 @@ level is based on which compliance tests the library can pass.
   * - Go
     - `go-jmespath <https://github.com/jmespath/go-jmespath>`__
     - Fully compliant
+  * - Java
+    - `jmespath-java <https://github.com/burtcorp/jmespath-java>`__
+    - Fully compliant
 
 In addition to the JMESPath libraries above, there are a number of
 miscellaneous JMESPath tools.


### PR DESCRIPTION
[jmespath-java](https://github.com/burtcorp/jmespath-java) is a new JMESPath implementation and we made our first public release today. It would be great if we could get a link from jmespath.org!