### PR TITLE
Fix an orphaned rule in the grammar

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -48,7 +48,8 @@ The grammar is specified using ABNF, as described in `RFC4234`_
 
 ::
 
-    expression        = sub-expression / index-expression / or-expression / identifier
+    expression        = sub-expression / index-expression  / comparator-expression
+    expression        =/ or-expression / identifier
     expression        =/ and-expression / not-expression / paren-expression
     expression        =/ "*" / multi-select-list / multi-select-hash / literal
     expression        =/ function-expression / pipe-expression / raw-string


### PR DESCRIPTION
I found an orphaned rule in the grammar while working on jmespath-java: The comparator-expression rule isn't used anywhere in the grammar, but it belongs with and-expression and or-expression.