### PR TITLE
Added JMESPath for Rust to the list of libraries.

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -36,6 +36,9 @@ level is based on which compliance tests the library can pass.
   * - Java
     - `jmespath-java <https://github.com/burtcorp/jmespath-java>`__
     - Fully compliant
+  * - Rust
+    - `jmespath.rs <https://github.com/mtdowling/jmespath.rs>`__
+    - Fully compliant
 
 In addition to the JMESPath libraries above, there are a number of
 miscellaneous JMESPath tools.


### PR DESCRIPTION
This adds Rust to the list of libraries. Crate: https://crates.io/crates/jmespath

There's also a crate that can statically compile JMESPath expressions at build time so that you know your expressions are correct and so that you don't need to parse them at runtime: https://crates.io/crates/jmespath-macros

There's a CLI that should have pretty close to a 1:1 implementation of jp available here: https://github.com/mtdowling/jmespath.rs/tree/master/jmespath-cli. I might try to one day get this creating cross platforms builds and try to convince you to switch jp to Rust. I'd of course have benchmarks to provide a motivation for the switch.

I also created a streaming implementation that I never finished if anyone is interested in checking it out. It isn't tested very well and doesn't have functions, but I got pretty far. I just don't think most JMESPath expressions are suitable for streaming searches considering how much buffering would be needed: https://github.com/mtdowling/jmespath.rs/tree/jmespath-streaming/jmespath-streaming