### PR TITLE
Added JMESPath for DotNet to the list of libraries.

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -39,6 +39,9 @@ level is based on which compliance tests the library can pass.
   * - Rust
     - `jmespath.rs <https://github.com/mtdowling/jmespath.rs>`__
     - Fully compliant
+  * - DotNet
+    - `jmespath.net <https://github.com/jdevillard/JmesPath.Net>`__
+    - Fully compliant
 
 In addition to the JMESPath libraries above, there are a number of
 miscellaneous JMESPath tools.


### PR DESCRIPTION
We've implement a DotNet librairies that implement the JMESPath specification and is fully compliant regarding the compliance tests.

The librairies is also available on Nuget : https://www.nuget.org/packages/JmesPath.Net/
