### PR TITLE
Add JMESPath for C++ to the list of libraries

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -42,6 +42,9 @@ level is based on which compliance tests the library can pass.
   * - DotNet
     - `jmespath.net <https://github.com/jdevillard/JmesPath.Net>`__
     - Fully compliant
+  * - C++
+    - `jmespath.cpp <https://github.com/robertmrk/jmespath.cpp>`__
+    - Fully compliant
 
 In addition to the JMESPath libraries above, there are a number of
 miscellaneous JMESPath tools.


### PR DESCRIPTION
[jmespath.cpp](https://github.com/robertmrk/jmespath.cpp) is a C++ implementation of JMESPath. The library is cross-platform, well tested and fully compliant with the specifications, it runs all the tests from [jmespath.test](https://github.com/jmespath/jmespath.test).
It's actually not a new library, I created it a few years ago but I forgot to request inclusion on the site.

It would be great if the library could be listed on the site.