### PR TITLE
Fix "count" to "length"

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -886,7 +886,7 @@ expression creates an array containing the total number of elements in the
 
 ::
 
-    foo[].[count(@), bar]
+    foo[].[length(@), bar]
 
 JMESPath assumes that all function arguments operate on the current node unless
 the argument is a ``literal`` or ``number`` token.  Because of this, an


### PR DESCRIPTION
I and at least some other JMESPath users were confused by the use of "count" into thinking that there was, in fact, a `count` function.  Now that I know it's the `length` function I was looking for, I assume this line in the specification should say "length" instead of "count".