### PR TITLE
jsoncons C++ library supports JMESPath

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -42,6 +42,9 @@ level is based on which compliance tests the library can pass.
   * - DotNet
     - `jmespath.net <https://github.com/jdevillard/JmesPath.Net>`__
     - Fully compliant
+  * - C++
+    - `jsoncons <https://github.com/danielaparker/jsoncons/blob/master/doc/ref/jmespath/jmespath.md>`__
+    - Fully compliant
 
 In addition to the JMESPath libraries above, there are a number of
 miscellaneous JMESPath tools.


### PR DESCRIPTION
[jsoncons](https://github.com/danielaparker/jsoncons), a self-contained, header-only C++ library for JSON and related formats, now [supports JMESPath](https://github.com/danielaparker/jsoncons/blob/master/doc/ref/jmespath/jmespath.md). It is fully compliant, it passes all [compliance tests](https://github.com/jmespath/jmespath.test).

I would like to request its inclusion in the list of JMESPath libraries.
