### PR TITLE
Moved the example jmespath-input json above the expression

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -20,10 +20,6 @@
     <div class="col-md-8">
       <div class="jmespath-demo">
         <form>
-          <div class="left-inner-addon">
-            <span class="glyphicon glyphicon-search"></span>
-            <input class="form-control jmespath-expression" type="text" placeholder="Expression" value="locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" size="40"/>
-          </div>
           <textarea class="form-control jmespath-input" rows="8">
 {
   "locations": [
@@ -33,6 +29,10 @@
     {"name": "Olympia", "state": "WA"}
   ]
 }</textarea>
+          <div class="left-inner-addon">
+            <span class="glyphicon glyphicon-search"></span>
+            <input class="form-control jmespath-expression" type="text" placeholder="Expression" value="locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" size="40"/>
+          </div>
         </form>
         <h3>Result</h3>
         <pre class="jmespath-result"></pre>

--- a/docs/_themes/jmespath/static/jmespath.css
+++ b/docs/_themes/jmespath/static/jmespath.css
@@ -97,6 +97,7 @@ h3.section-distinct {
 .jmespath-demo .jmespath-expression {
   font-family: Consolas, Monaco, Menlo, 'Courier New', monospace;
   font-size: 14px;
+  margin-top: 20px;
   margin-bottom: 20px;
 }
 .jmespath-demo .jmespath-result {


### PR DESCRIPTION
The expression field should be under the example json because it's based on it