### PR TITLE
remove deprecated raw string literals from examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -185,7 +185,7 @@ The most interesting of those three expressions is the
 ``tags[?Key=='Name'].Values[] | [0]`` part.  Let's examine that further.
 
 The first thing to notice is the we're filtering down the list associated
-with the ``tags`` key.  The ``tags[?Key==`Name`]`` tells us to only include
+with the ``tags`` key.  The ``tags[?Key=='Name']`` tells us to only include
 list elements that contain a ``Key`` whose value is ``Name``.  From those
 filtered list elements we're going to take the ``Values`` key and flatten
 the list.  Finally, the ``| [0]`` will take the entire list and extract the

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -1094,7 +1094,7 @@ As a final example, here is the steps for evaluating ``abs(to_number(bar))``:
     - 1
   * - ``abs(-1)``
     - 1
-  * - ``abs(`abc`)``
+  * - ``abs('abc')``
     - ``<error: invalid-type>``
 
 
@@ -1160,34 +1160,34 @@ the string contains the provided ``$search`` argument.
     - Expression
     - Result
   * - n/a
-    - ``contains(`foobar`, `foo`)``
+    - ``contains('foobar', 'foo')``
     - ``true``
   * - n/a
-    - ``contains(`foobar`, `not`)``
+    - ``contains('foobar', 'not')``
     - ``false``
   * - n/a
-    - ``contains(`foobar`, `bar`)``
+    - ``contains('foobar', 'bar')``
     - ``true``
   * - n/a
-    - ``contains(`false`, `bar`)``
+    - ``contains(`false`, 'bar')``
     - ``<error: invalid-type>``
   * - n/a
-    - ``contains(`foobar`, 123)``
+    - ``contains('foobar', 123)``
     - ``false``
   * - ``["a", "b"]``
-    - ``contains(@, `a`)``
+    - ``contains(@, 'a')``
     - ``true``
   * - ``["a"]``
-    - ``contains(@, `a`)``
+    - ``contains(@, 'a')``
     - ``true``
   * - ``["a"]``
-    - ``contains(@, `b`)``
+    - ``contains(@, 'b')``
     - ``false``
   * - ``["foo", "bar"]``
-    - ``contains(@, `foo`)``
+    - ``contains(@, 'foo')``
     - ``true``
   * - ``["foo", "bar"]``
-    - ``contains(@, `b`)``
+    - ``contains(@, 'b')``
     - ``false``
 
 
@@ -1215,7 +1215,7 @@ Returns the next highest integer value by rounding up if necessary.
     - 2
   * - ``ceil(`1`)``
     - 1
-  * - ``ceil(`abc`)``
+  * - ``ceil(`"abc"`)``
     - ``null``
 
 
@@ -1238,14 +1238,14 @@ function returns ``false``.
   * - Given
     - Expression
     - Result
-  * - ``foobarbaz``
-    - ``ends_with(@, ``baz``)``
+  * - ``"foobarbaz"``
+    - ``ends_with(@, 'baz')``
     - ``true``
-  * - ``foobarbaz``
-    - ``ends_with(@, ``foo``)``
+  * - ``"foobarbaz"``
+    - ``ends_with(@, 'foo')``
     - ``false``
-  * - ``foobarbaz``
-    - ``ends_with(@, ``z``)``
+  * - ``"foobarbaz"``
+    - ``ends_with(@, 'z')``
     - ``true``
 
 
@@ -1297,16 +1297,16 @@ together using the ``$glue`` argument as a separator between each.
     - Expression
     - Result
   * - ``["a", "b"]``
-    - ``join(`, `, @)``
+    - ``join(', ', @)``
     - "a, b"
   * - ``["a", "b"]``
-    - ``join(````, @)``
+    - ``join('', @)``
     - "ab"
   * - ``["a", false, "b"]``
-    - ``join(`, `, @)``
+    - ``join(', ', @)``
     - ``<error: invalid-type>``
   * - ``[false]``
-    - ``join(`, `, @)``
+    - ``join(', ', @)``
     - ``<error: invalid-type>``
 
 .. _func-keys:
@@ -1370,7 +1370,7 @@ Returns the length of the given argument using the following types rules:
     - Expression
     - Result
   * - n/a
-    - ``length(`abc`)``
+    - ``length('abc')``
     - 3
   * - "current"
     - ``length(@)``
@@ -1653,7 +1653,7 @@ Reverses the order of the ``$argument``.
   * - ``["a", "b", "c", 1, 2, 3]``
     - ``reverse(@)``
     - ``[3, 2, 1, "c", "b", "a"]``
-  * - ``"abcd``
+  * - ``"abcd"``
     - ``reverse(@)``
     - ``dcba``
 
@@ -1758,14 +1758,14 @@ this function returns ``false``.
   * - Given
     - Expression
     - Result
-  * - ``foobarbaz``
-    - ``starts_with(@, ``foo``)``
+  * - ``"foobarbaz"``
+    - ``starts_with(@, 'foo')``
     - ``true``
-  * - ``foobarbaz``
-    - ``starts_with(@, ``baz``)``
+  * - ``"foobarbaz"``
+    - ``starts_with(@, 'baz')``
     - ``false``
-  * - ``foobarbaz``
-    - ``starts_with(@, ``f``)``
+  * - ``"foobarbaz"``
+    - ``starts_with(@, 'f')``
     - ``true``
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -593,7 +593,7 @@ string ``foo``.
     }
 
 The ``@`` character in the example above refers to the current element being
-evaluated in ``myarray``.  The expression ``contains(@, `foo`)`` will return
+evaluated in ``myarray``.  The expression ``contains(@, 'foo')`` will return
 ``true`` if the current element in the ``myarray`` array contains the string
 ``foo``.
 


### PR DESCRIPTION
I ran into a confusing problem where examples from the website weren't working in the [java library](https://github.com/burtcorp/jmespath-java), and I narrowed it down to raw strings inside backticks. I was a bit confused at first because the ABNF made it look like only JSON was allowed inside backticks. 

Based on the this proposal I found on the site with status "accepted": https://jmespath.org/proposals/raw-string-literals.html it looks like non-json inside backticks is now deprecated. I also see that the tests were [updated](https://github.com/jmespath/jmespath.test/commit/2c579baa07e9483e3fd18eda76b0e6660a447e3d) to reflect this.

Given that implementations aren't tested against the old raw strings syntax (and one prominent implementation doesn't work) it makes sense to me the examples on the site should not include them.