### PR TITLE
Fix number of digits after exponents and fractionals

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -146,8 +146,8 @@ The grammar is specified using ABNF, as described in `RFC4234`_
     decimal-point = %x2E       ; .
     digit1-9 = %x31-39         ; 1-9
     e = %x65 / %x45            ; e E
-    exp = e [ minus / plus ] 1*DIGIT
-    frac = decimal-point 1*DIGIT
+    exp = e [ minus / plus ] *DIGIT
+    frac = decimal-point *DIGIT
     int = zero / ( digit1-9 *DIGIT )
     minus = %x2D               ; -
     plus = %x2B                ; +


### PR DESCRIPTION
Seems that not only one number is allowed in fractionals after dots and exponents after `+` / `-` operator. See [RFC 4234, section 3.7](https://datatracker.ietf.org/doc/html/rfc4234#section-3.7).