### PR TITLE
Specify explicit error type for all error scenarios

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -987,8 +987,8 @@ As a shorthand, the type ``any`` is used to indicate that the argument can be
 of any type (``array|object|number|string|boolean|null``).
 
 JMESPath functions are required to type check their input arguments.
-Specifying an invalid type for a function argument will result in a JMESPath
-error.
+Specifying an invalid type for a function argument will result in a
+``invalid-type`` error.
 
 The expression type, denoted by ``&expression``, is used to specify a
 expression that is not immediately evaluated.  Instead, a reference to that
@@ -1718,8 +1718,8 @@ in the array of ``elements``, the ``expr`` expression is applied and the
 resulting value is used as the key used when sorting the ``elements``.
 
 If the result of evaluating the ``expr`` against the current array element
-results in type other than a ``number`` or a ``string``, a type error will
-occur.
+results in type other than a ``number`` or a ``string``, an ``invalid-type``
+error will occur.
 
 Below are several examples using the ``people`` array (defined above) as the
 given input.  ``sort_by`` follows the same sorting logic as the ``sort``

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -227,6 +227,27 @@ Examples
    search("\u2713", {"\u2713": "value"}) -> "value"
 
 
+.. _errors:
+
+Errors
+======
+
+Errors may be raised during the JMEspath evaluation process. How and when errors
+are raised is implementation specific, but implementations should indicate to
+the caller when errors have occurred.
+
+The following errors are defined:
+
+* ``invalid-type`` is raised when an invalid type is encountered during the
+  evaluation process.
+* ``invalid-value`` is raised when an invalid value is encountered during the
+  evaluation process.
+* ``unknown-function`` is raised when an unknown function is encountered during
+  the evaluation process.
+* ``invalid-arity`` is raised when an invalid number of function arguments is
+  encountered during the evaluation process.
+
+
 .. _subexpressions:
 
 SubExpressions

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -348,7 +348,7 @@ Slice expressions adhere to the following rules:
 * If no stop position is given, it is assumed to be the length of the array if
   the given step is greater than 0 or 0 if the given step is less than 0.
 * If the given step is omitted, it it assumed to be 1.
-* If the given step is 0, an error MUST be raised.
+* If the given step is 0, an ``invalid-value`` error MUST be raised.
 * If the element being sliced is not an array, the result is ``null``.
 * If the element being sliced is an array and yields no results, the result
   MUST be an empty array.

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -227,27 +227,6 @@ Examples
    search("\u2713", {"\u2713": "value"}) -> "value"
 
 
-.. _errors:
-
-Errors
-======
-
-Errors may be raised during the JMEspath evaluation process. How and when errors
-are raised is implementation specific, but implementations should indicate to
-the caller when errors have occurred.
-
-The following errors are defined:
-
-* ``invalid-type`` is raised when an invalid type is encountered during the
-  evaluation process.
-* ``invalid-value`` is raised when an invalid value is encountered during the
-  evaluation process.
-* ``unknown-function`` is raised when an unknown function is encountered during
-  the evaluation process.
-* ``invalid-arity`` is raised when an invalid number of function arguments is
-  encountered during the evaluation process.
-
-
 .. _subexpressions:
 
 SubExpressions


### PR DESCRIPTION
This PR changes the wording of the spec to state the specific error type in all error scenarios.

I have found 34 occurrences of the word "error" in the spec. In most cases, the spec indicates the exact type of error, e.g., `invalid-type`, `unknown-function`, `invalid-arity`. However, there are three occurrences when no explicit error type is mentioned.

In two cases, I think the right error type is ``invalid-type``. In the third case (**Slices** section), I'm not sure what the error type should be. Maybe `invalid-value`, but it's not specified anywhere in the spec (I see only three error types defined). Related to this, I have raised #116 to add a section for error handling.

```diff
- If the given step is 0, an error MUST be raised.
+ If the given step is 0, an `invalid-value` error MUST be raised.
```