### PR TITLE
Add section for error handling

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -227,6 +227,27 @@ Examples
    search("\u2713", {"\u2713": "value"}) -> "value"
 
 
+.. _errors:
+
+Errors
+======
+
+Errors may be raised during the JMEspath evaluation process. How and when errors
+are raised is implementation specific, but implementations should indicate to
+the caller when errors have occurred.
+
+The following errors are defined:
+
+* ``invalid-type`` is raised when an invalid type is encountered during the
+  evaluation process.
+* ``invalid-value`` is raised when an invalid value is encountered during the
+  evaluation process.
+* ``unknown-function`` is raised when an unknown function is encountered during
+  the evaluation process.
+* ``invalid-arity`` is raised when an invalid number of function arguments is
+  encountered during the evaluation process.
+
+
 .. _subexpressions:
 
 SubExpressions


### PR DESCRIPTION
This PR adds a section about error handling.

The following statement is written twice inside the **Function Evaluation** section:
> How and when this error is raised is implementation specific

IMHO, this statement applies to all error handling scenarios. So instead of making that statement specific to function evaluation, it could be moved to the section about error handling.

The spec has 34 occurrences of the word "error", but it does not really codify how errors are raised.
The spec does not have a list of error types and it does not have guidelines about when to use these error types.
