### PR TITLE
Fix multi-select-hash JSON typo

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -621,7 +621,7 @@ Examples
 --------
 
 Given a ``multi-select-hash`` expression ``{foo: one.two, bar: bar}`` and the
-data ``{"bar": "bar", {"one": {"two": "one-two"}}}``, the expression is
+data ``{"bar": "bar", "one": {"two": "one-two"}}``, the expression is
 evaluated as follows:
 
 1. A hash is created: ``{}``


### PR DESCRIPTION
It looks like the multi-select-hash spec has invalid JSON for example data. Just removing a set of braces to make the example valid.